### PR TITLE
Created /npm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ For more information check out the [Contribution Guidelines](CONTRIBUTING.md)
 | `/catpic`                 | Shows a random cat picture.                               | [Cat Pic API](https://aws.random.cat/meow/)                         |
 | `/joke`                   | Give you a random joke.                                   | [Joke API](https://sv443.net/jokeapi/v2/)                           |
 | `/chuck`                  | Shows a random joke about Chuck Norris                    | [Chuck Norris API](https://api.chucknorris.io/jokes/random)         |
+| `/npm` | Query the NPM registry for npm package details | [NPM Registry](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md)
 
 ## :wrench: Installation
 

--- a/commands/npm.js
+++ b/commands/npm.js
@@ -1,0 +1,35 @@
+const { SlashCommandBuilder } = require('discord.js');
+const axios = require('axios').default;
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('npm')
+    .setDescription('Get package details from the NPM Registry')
+    .addStringOption((option) => {
+      return option.setName('package_name').setDescription('Package name').setRequired(true)
+    })
+    .addStringOption((option) => {
+      return option.setName('version').setDescription('Package specific version or latest').setRequired(false)
+    }),
+    async execute(interaction) {
+      const packageName = interaction.options.getString('package_name').toLowerCase(); 
+      const version = interaction.options.getString('version');
+
+      axios({
+        url: version
+          ? `https://registry.npmjs.org/${packageName}/${version}`
+          : `https://registry.npmjs.org/${packageName}`,
+        method: 'GET',
+        responseType: 'json',
+      }).then(async (response) => {
+        await interaction.reply({
+          content: 'Package Name: ' + response.data.name
+          + '\n' + 'Package Description: ' + response.data.description
+          + '\n' + 'Package Author(email): ' + response.data.author.name + ' - ' + response.data.author.email
+          + '\n' + 'Package Repository: ' + response.data.repository.url,
+        });
+      }).catch(async (error) => {
+        await interaction.reply('NPM command run with errors');
+      });
+    }
+}


### PR DESCRIPTION
# Added new command /npm

- [x] Code is formatted correctly
- [x] Code is tested before submitting
- [x] Added command to README.md commands list

## Details

### Description
The bot will query on the NPM Registry API and return defails about packages registered on the NPM. The api endpoint can be found here https://registry.npmjs.org/

### Parameters:

Required - package name: The package's name that the user wants to get its details
Optional - package version: Specific package version or latest
