### PR TITLE
Add /randomcolor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ For more information check out the [Contribution Guidelines](CONTRIBUTING.md)
 | `/meme`                   | Send Random Memes.                                        | [Reddit Random Memes Api](https://reddit-meme-api.herokuapp.com)                 |
 | `/list-data-breaches`     | Lists data breaches using the haveibeenpwned.com API      | [haveibeenpwned.com](https://haveibeenpwned.com/api)                             |
 | `/onthisday`              | Shows a random history event happended on this date.      | [ZenQuotes](https://today.zenquotes.io/api/)                                     |
-| `/fruit`                  | Get interesting information about fruit                   | [Fruityvice](https://www.fruityvice.com/)                                        |
+| `/fruit`                  | Get interesting information about fruit                   | [Fruityvice](https://www.fruityvice.com/)
+| `/randomcolor`            | Shows a random color with HEX and RGB format              | [xColors API](https://x-colors.herokuapp.com/), [Single Color Image API](https://singlecolorimage.com/api.html)
 
 ## :wrench: Installation
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ For more information check out the [Contribution Guidelines](CONTRIBUTING.md)
 | `/meme`                   | Send Random Memes.                                        | [Reddit Random Memes Api](https://reddit-meme-api.herokuapp.com)                 |
 | `/list-data-breaches`     | Lists data breaches using the haveibeenpwned.com API      | [haveibeenpwned.com](https://haveibeenpwned.com/api)                             |
 | `/onthisday`              | Shows a random history event happended on this date.      | [ZenQuotes](https://today.zenquotes.io/api/)                                     |
-| `/fruit`                  | Get interesting information about fruit                   | [Fruityvice](https://www.fruityvice.com/)
-| `/randomcolor`            | Shows a random color with HEX and RGB format              | [xColors API](https://x-colors.herokuapp.com/), [Single Color Image API](https://singlecolorimage.com/api.html)
+| `/fruit`                  | Get interesting information about fruit                   | [Fruityvice](https://www.fruityvice.com/)                                        |
+| `/randomcolor`            | Shows a random color with HEX and RGB format              | [xColors API](https://x-colors.herokuapp.com/), [Single Color Image API](https://singlecolorimage.com/api.html) |
 
 ## :wrench: Installation
 

--- a/commands/randomcolor.js
+++ b/commands/randomcolor.js
@@ -1,0 +1,39 @@
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js")
+const axios = require("axios").default
+
+const getColorImageLink = (hex) => {
+  return `https://singlecolorimage.com/get/${hex}/100x100`
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("randomcolor")
+    .setDescription("Get a random color in HEX and RGB format"),
+  async execute(interaction) {
+    await axios({
+      method: "get",
+      url: "https://x-colors.herokuapp.com/api/random",
+      responseType: "json",
+    })
+      .then((response) => {
+        hexData = response.data.hex
+        rgbData = response.data.rgb
+        const embed = new EmbedBuilder()
+          .setColor(hexData)
+          .setTitle("Your random color")
+          .setImage(getColorImageLink(hexData.slice(1)))
+          .addFields(
+            { name: "HEX format", value: hexData },
+            { name: "RGB format", value: rgbData }
+          )
+          .setTimestamp()
+        interaction.reply({ embeds: [embed] })
+      })
+      .catch((error) => {
+        interaction.reply({
+          content: "There was an error while executing this command!",
+          ephemeral: true,
+        })
+      })
+  },
+}


### PR DESCRIPTION
# Added new command `/randomcolor`

Issue: #109 

- [x] Added command to README.md commands list
- [x] Code is tested before submitting
- [x] Code is formatted with prettier (`npm run format`)
- [x] Deleted all console.log() or console.error() statements
- [x] Correct error handling => No 'The application did not respond' errors

## Details

The command gives user a random color with two different format, HEX number and RGB format. It also shows how the color looks like by calling another API to generate solid color image so it can be used in the embed.

![image](https://user-images.githubusercontent.com/20255031/194939239-f0a0911d-ba11-457b-ad79-d3e58adfca85.png)
