### PR TITLE
Add /earthevent command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For more information check out the [Contribution Guidelines](CONTRIBUTING.md)
 | `/xkcd`                   | Shows a random xkcd comic.                                | [xkcd Swagger REST API](https://www.programmableweb.com/api/xkcd-swagger-rest-api-v2)       |
 | `/roboavatar`             | Create a Robotor Avatar by entering a string.             | [Robo Avatar API](https://robohash.org/)                                                    |
 | `/inspiration`            | Get Inspiration.                                          | [goprogram API](https://api.goprogram.ai/inspiration/)                                      |
-
+| `/earthevent`            | Return a natural event that has occurred in the last 30 days.                                          | [EONET API](https://eonet.gsfc.nasa.gov)                                      |
 
 ## :wrench: Installation
 

--- a/commands/earthevent.js
+++ b/commands/earthevent.js
@@ -13,7 +13,8 @@ module.exports = {
       url: "https://eonet.gsfc.nasa.gov/api/v3/events?limit=60&days=30",
       responseType: "json",
     })
-      .then((response) => {
+      .then(async (response) => {
+        await interaction.deferReply({ ephemeral: false })
         // get number of events in the past 30 days, limited to 60
         let totalEvents = response.data.events.length
         // choose random event from eonet API response
@@ -70,8 +71,8 @@ module.exports = {
         // work around: parseInt date before returning month
         let month = months[parseInt(date.slice(5, 7))]
 
-        interaction.reply(
-            cat +
+        interaction.editReply(
+          cat +
             ": " +
             event.title +
             " - " +
@@ -87,7 +88,7 @@ module.exports = {
         )
       })
       .catch(() => {
-        interaction.reply(
+        interaction.editReply(
           "The Earth Observatory Natural Event Tracker API did not respond."
         )
       })

--- a/commands/earthevent.js
+++ b/commands/earthevent.js
@@ -1,0 +1,95 @@
+const { SlashCommandBuilder } = require("discord.js")
+const axios = require("axios").default
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("earthevent")
+    .setDescription(
+      "Return a natural event that has occurred in the last 30 days."
+    ),
+  async execute(interaction) {
+    await axios({
+      method: "get",
+      url: "https://eonet.gsfc.nasa.gov/api/v3/events?limit=60&days=30",
+      responseType: "json",
+    })
+      .then((response) => {
+        // get number of events in the past 30 days, limited to 60
+        let totalEvents = response.data.events.length
+        // choose random event from eonet API response
+        let randomIndex = Math.floor(Math.random() * totalEvents)
+        let event = response.data.events[randomIndex]
+
+        // if category is plural, change to singular
+        let cat = event.categories[0].title
+        if (cat[cat.length - 1] == "s") {
+          cat = cat.slice(0, -1)
+        }
+
+        // if there were multiple occurrences of the event, return the latest
+        let date = event.geometry[event.geometry.length - 1].date
+        date = date.slice(0, 10)
+        let year = date.slice(0, 4)
+        let day = date.slice(8)
+        switch (day) {
+          case "01":
+          case "21":
+          case "31":
+            day = `${day}st`
+            break
+          case "02":
+          case "22":
+            day = `${day}nd`
+            break
+          case "03":
+          case "23":
+            day = `${day}rd`
+            break
+          default:
+            day = `${day}th`
+        }
+        if (day[0] == 0) {
+          day = day.slice(1)
+        }
+
+        // formatting changes 10, 11, and 12 from strings("10") to ints(10) for some reason
+        let months = {
+          01: "January",
+          02: "February",
+          03: "March",
+          04: "April",
+          05: "May",
+          06: "June",
+          07: "July",
+          08: "August",
+          09: "September",
+          10: "October",
+          11: "November",
+          12: "December",
+        }
+        // work around: parseInt date before returning month
+        let month = months[parseInt(date.slice(5, 7))]
+
+        interaction.reply(
+            cat +
+            ": " +
+            event.title +
+            " - " +
+            month +
+            " " +
+            day +
+            ", " +
+            year +
+            "\n" +
+            "Learn more [here](" +
+            event.sources[0].url +
+            ")"
+        )
+      })
+      .catch(() => {
+        interaction.reply(
+          "The Earth Observatory Natural Event Tracker API did not respond."
+        )
+      })
+  },
+}


### PR DESCRIPTION
# Added new command /earthevent

Should close #140

- [x] Added command to README.md commands list
- [x] Code is tested before submitting
- [x] Code is formatted with prettier (`npm run format`)
- [x] Deleted all console.log() or console.error() statements
- [x] Correct error handling => No 'The application did not respond' errors

## Details

/earthevent returns a natural event (forest fire, volcanic eruption, tropical storm, etc.) its name and source url, that has occurred in the past 30 days.

example output:
<img width="479" alt="test example" src="https://user-images.githubusercontent.com/59973863/196247987-33b08c90-4575-44ec-981f-373f36b1268e.png">
